### PR TITLE
perf: Use string interning for HTTP methods & popular headers

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@ use std::str;
 
 use pyo3::create_exception;
 use pyo3::exceptions::PyException;
+use pyo3::intern;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyList, PyString};
 use pyo3::Python;
@@ -79,7 +80,29 @@ impl RequestParser {
                                 Py::new(
                                     py,
                                     Header {
-                                        name: PyString::new(py, h.name).into(),
+                                        name: {
+                                            match h.name {
+                                                "Host" => intern!(py, "Host"),
+                                                "Connection" => intern!(py, "Connection"),
+                                                "Cache-Control" => {
+                                                    intern!(py, "Cache-Control")
+                                                }
+                                                "Accept" => intern!(py, "Accept"),
+                                                "User-Agent" => intern!(py, "User-Agent"),
+                                                "Accept-Encoding" => {
+                                                    intern!(py, "Accept-Encoding")
+                                                }
+                                                "Accept-Language" => {
+                                                    intern!(py, "Accept-Language")
+                                                }
+                                                "Accept-Charset" => {
+                                                    intern!(py, "Accept-Charset")
+                                                }
+                                                "Cookie" => intern!(py, "Cookie"),
+                                                name => PyString::new(py, name),
+                                            }
+                                        }
+                                        .into(),
                                         value: PyBytes::new(py, h.value).into(),
                                     },
                                 )
@@ -87,8 +110,22 @@ impl RequestParser {
                             }),
                         )
                         .into();
+                        let method = match request.method.unwrap() {
+                            "GET" => intern!(py, "GET"),
+                            "POST" => intern!(py, "POST"),
+                            "PUT" => intern!(py, "PUT"),
+                            "PATCH" => intern!(py, "PATCH"),
+                            "DELETE" => intern!(py, "DELETE"),
+                            "HEAD" => intern!(py, "HEAD"),
+                            "OPTIONS" => intern!(py, "OPTIONS"),
+                            "TRACE" => intern!(py, "TRACE"),
+                            "CONNECT" => intern!(py, "CONNECT"),
+                            other => PyString::new(py, other),
+                        }
+                        .into();
+
                         Some(ParsedRequest {
-                            method: PyString::new(py, request.method.unwrap()).into(),
+                            method,
                             path: PyString::new(py, request.path.unwrap()).into(),
                             version: request.version.unwrap(),
                             headers: header_list,


### PR DESCRIPTION
Hey! Thank you for working on this!

This PR shows possible performance improvements via string interning. I guess it might be a bit slower for one-off use cases (but I assume they are pretty rare) due to the cell overhead, but shows a consistent improvement in the benchmark locally - 1.44 µs (main) vs. 1.26 µs (this branch) which is >10%. 

Let me know what you think! The PR is mostly to start a discussion about whether it is the right direction or not.

P.S. header names are chosen based on the benchmark and are highly arbitrary, but I guess that interning should be done for the most popular ones.