### PR TITLE
Fix typos in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ assert parsed is not None
 assert parsed.method == "GET"
 assert parsed.path == "/index.html"
 assert parsed.version == 1
-assert parsed.body_start_byte_offset == len(buff)
-headers = [(h.name, h.value.encode()) for h in parsed.headers]
-assert headers == [(b"Host", b"example.com")]
+assert parsed.body_start_offset == len(buff)
+headers = [(h.name.encode(), h.value) for h in parsed.headers]
+assert headers == [(b"Host", b"example.domain")]
 ```


### PR DESCRIPTION
Hey there,

Pretty interesting one.

I was playing around with this and ran into issues running the README example. Here's a PR with the changes I had to make to make it pass. :)

Also I had a question -- how does `httparse` (the Rust version or this one) handle parsing the body? Is the client code supposed to basically join the rest of its buffer or whatever it's using to get data from the network, starting at `body_start_offset`? Edit: answered that question for myself — looks like that works!