### PR TITLE
Macro for interning & clippy fixes

### DIFF
--- a/python/httparse/__init__.py
+++ b/python/httparse/__init__.py
@@ -8,6 +8,7 @@ from httparse._httparse import (
     InvalidHeaderName,
     InvalidHeaderValue,
     InvalidHTTPVersion,
+    InvalidStatus,
     InvalidToken,
     ParsedRequest,
     ParsingError,
@@ -28,4 +29,5 @@ __all__ = (
     "InvalidToken",
     "TooManyHeaders",
     "InvalidHTTPVersion",
+    "InvalidStatus",
 )

--- a/python/httparse/_httparse.pyi
+++ b/python/httparse/_httparse.pyi
@@ -35,6 +35,9 @@ class TooManyHeaders(ParsingError):
 class InvalidHTTPVersion(ParsingError):
     pass
 
+class InvalidStatus(ParsingError):
+    pass
+
 class Header(Protocol):
     @property
     def name(self) -> str: ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ create_exception!(_httparse, InvalidByteRangeInResponseStatus, ParsingError);
 create_exception!(_httparse, InvalidToken, ParsingError);
 create_exception!(_httparse, TooManyHeaders, ParsingError);
 create_exception!(_httparse, InvalidHTTPVersion, ParsingError);
+create_exception!(_httparse, InvalidStatus, ParsingError);
 
 #[pyclass(module = "httparse._httparse")]
 #[derive(Clone, Debug)]
@@ -27,7 +28,7 @@ struct Header {
 
 #[pymethods]
 impl Header {
-    fn __repr__(&self, py: Python) -> PyResult<String> {
+    fn __repr__(&self, py: Python<'_>) -> PyResult<String> {
         let value = self.value.as_ref(py).as_bytes();
         Ok(format!(
             "Header(name=\"{}\", value=b\"{}\")",
@@ -35,7 +36,7 @@ impl Header {
             str::from_utf8(value)?
         ))
     }
-    fn __str__(&self, py: Python) -> PyResult<String> {
+    fn __str__(&self, py: Python<'_>) -> PyResult<String> {
         self.__repr__(py)
     }
 }
@@ -80,72 +81,68 @@ impl RequestParser {
     fn py_new() -> Self {
         RequestParser {}
     }
-    fn parse(&mut self, buff: PyData, py: Python) -> PyResult<Option<ParsedRequest>> {
-        let mut headers = [httparse::EMPTY_HEADER; 256];
-        let mut request = httparse::Request::new(&mut headers);
+    fn parse(&mut self, buff: PyData, py: Python<'_>) -> PyResult<Option<ParsedRequest>> {
+        let mut empty_headers = [httparse::EMPTY_HEADER; 256];
+        let mut request = httparse::Request::new(&mut empty_headers);
         let maybe_status = request.parse(match buff {
             PyData::Bytes(d) => d.as_bytes(),
             PyData::ByteArray(d) => unsafe { d.as_bytes() },
         });
         match maybe_status {
-            Ok(status) => Ok({
-                match status.is_complete() {
-                    true => {
-                        let header_list: Py<PyList> = PyList::new(
+            Ok(httparse::Status::Complete(body_start_offset)) => {
+                let headers: Py<PyList> = PyList::new(
+                    py,
+                    request.headers.iter_mut().map(|h| {
+                        Py::new(
                             py,
-                            request.headers.into_iter().map(|h| {
-                                Py::new(
-                                    py,
-                                    Header {
-                                        name: {
-                                            intern_match!(
-                                                py,
-                                                h.name,
-                                                "Host",
-                                                "Connection",
-                                                "Cache-Control",
-                                                "Accept",
-                                                "User-Agent",
-                                                "Accept-Encoding",
-                                                "Accept-Language",
-                                                "Accept-Charset",
-                                                "Cookie"
-                                            )
-                                        }
-                                        .into(),
-                                        value: PyBytes::new(py, h.value).into(),
-                                    },
-                                )
-                                .unwrap()
-                            }),
+                            Header {
+                                name: {
+                                    intern_match!(
+                                        py,
+                                        h.name,
+                                        "Host",
+                                        "Connection",
+                                        "Cache-Control",
+                                        "Accept",
+                                        "User-Agent",
+                                        "Accept-Encoding",
+                                        "Accept-Language",
+                                        "Accept-Charset",
+                                        "Cookie"
+                                    )
+                                }
+                                .into(),
+                                value: PyBytes::new(py, h.value).into(),
+                            },
                         )
-                        .into();
-                        let method = intern_match!(
-                            py,
-                            request.method.unwrap(),
-                            "GET",
-                            "POST",
-                            "PUT",
-                            "PATCH",
-                            "DELETE",
-                            "HEAD",
-                            "OPTIONS",
-                            "TRACE",
-                            "CONNECT"
-                        )
-                        .into();
+                        .unwrap()
+                    }),
+                )
+                .into();
+                let method = intern_match!(
+                    py,
+                    request.method.unwrap(),
+                    "GET",
+                    "POST",
+                    "PUT",
+                    "PATCH",
+                    "DELETE",
+                    "HEAD",
+                    "OPTIONS",
+                    "TRACE",
+                    "CONNECT"
+                )
+                .into();
 
-                        Some(ParsedRequest {
-                            method,
-                            path: PyString::new(py, request.path.unwrap()).into(),
-                            version: request.version.unwrap(),
-                            headers: header_list,
-                            body_start_offset: status.unwrap(),
-                        })
-                    }
-                    false => None,
-                }
-            }),
+                Ok(Some(ParsedRequest {
+                    method,
+                    path: PyString::new(py, request.path.unwrap()).into(),
+                    version: request.version.unwrap(),
+                    headers,
+                    body_start_offset,
+                }))
+            }
+            Ok(httparse::Status::Partial) => Ok(None),
             Err(parse_error) => match parse_error {
                 httparse::Error::HeaderName => Err(InvalidHeaderName::new_err(())),
                 httparse::Error::HeaderValue => Err(InvalidHeaderValue::new_err(())),
@@ -153,31 +150,32 @@ impl RequestParser {
                 httparse::Error::Token => Err(InvalidToken::new_err(())),
                 httparse::Error::TooManyHeaders => Err(TooManyHeaders::new_err(())),
                 httparse::Error::Version => Err(InvalidHTTPVersion::new_err(())),
-                _ => panic!(),
+                httparse::Error::Status => Err(InvalidStatus::new_err(())),
             },
         }
     }
 }
 
 #[pymodule]
-fn _httparse(_py: Python, m: &PyModule) -> PyResult<()> {
+fn _httparse(py: Python<'_>, m: &PyModule) -> PyResult<()> {
     m.add_class::<Header>()?;
     m.add_class::<ParsedRequest>()?;
     m.add_class::<RequestParser>()?;
-    m.add("InvalidChunkSize", _py.get_type::<InvalidChunkSize>())?;
-    m.add("ParsingError", _py.get_type::<ParsingError>())?;
-    m.add("InvalidHeaderName", _py.get_type::<InvalidHeaderName>())?;
-    m.add("InvalidHeaderValue", _py.get_type::<InvalidHeaderValue>())?;
+    m.add("InvalidChunkSize", py.get_type::<InvalidChunkSize>())?;
+    m.add("ParsingError", py.get_type::<ParsingError>())?;
+    m.add("InvalidHeaderName", py.get_type::<InvalidHeaderName>())?;
+    m.add("InvalidHeaderValue", py.get_type::<InvalidHeaderValue>())?;
     m.add(
         "InvalidByteInNewLine",
-        _py.get_type::<InvalidByteInNewLine>(),
+        py.get_type::<InvalidByteInNewLine>(),
     )?;
     m.add(
         "InvalidByteRangeInResponseStatus",
-        _py.get_type::<InvalidByteRangeInResponseStatus>(),
+        py.get_type::<InvalidByteRangeInResponseStatus>(),
     )?;
-    m.add("InvalidToken", _py.get_type::<InvalidToken>())?;
-    m.add("TooManyHeaders", _py.get_type::<TooManyHeaders>())?;
-    m.add("InvalidHTTPVersion", _py.get_type::<InvalidHTTPVersion>())?;
+    m.add("InvalidToken", py.get_type::<InvalidToken>())?;
+    m.add("TooManyHeaders", py.get_type::<TooManyHeaders>())?;
+    m.add("InvalidHTTPVersion", py.get_type::<InvalidHTTPVersion>())?;
+    m.add("InvalidStatus", py.get_type::<InvalidStatus>())?;
     Ok(())
 }


### PR DESCRIPTION
Hey!

These are assorted changes that:

- Make the interning process more reliable as there is no need to duplicate the string in the match statement
- Adjust the code a bit so various Clippy lints are happy (I didn't include them though)
- Add `InvalidStatus` exception

it also reduces nesting a bit, which IMO improves readability. Let me know what you think :)